### PR TITLE
Auto-determine kernel and initrd locations

### DIFF
--- a/overlays/initrd/usr/local/bin/stiefel-server
+++ b/overlays/initrd/usr/local/bin/stiefel-server
@@ -6,6 +6,7 @@ import io
 import json
 import multiprocessing
 import os
+import re
 import socket
 import subprocess
 import struct
@@ -94,8 +95,6 @@ CHALLENGE = base64.b64encode(os.urandom(16)).decode('ascii')
 
 BLKDEV = cmdlineargs["stiefel_bootdisk"]
 BOOTPART = cmdlineargs["stiefel_bootpart"]
-KERNEL = cmdlineargs["stiefel_kernel"]
-INITRD = cmdlineargs["stiefel_initrd"]
 UNSECURE = bool(int(cmdlineargs.get("stiefel_unsecure", "0")))
 
 multiprocessing.Process(target=continuous_network_setup).start()
@@ -116,15 +115,65 @@ with open("/etc/nbd-server/config", "w") as nbdconfigfile:
 print(f"opening NBD server for {BLKDEV}")
 subprocess.check_call(['systemctl', 'start', 'nbd-server'])
 
+def read_binary(filename):
+    if not os.path.isfile(filename):
+        return None
+    with open(filename, 'rb') as fileobj:
+        return fileobj.read()
+
+
+def find_kernel_and_initrd():
+    # kernel hints were manually created for the stiefelsystem
+    stiefelsystem_config = read_binary("/mnt/stiefelsystem.json")
+    if stiefelsystem_config is not None:
+        stiefelsystem_config_json = json.loads(stiefelsystem_config)
+        yield os.path.normpath(
+            b'/mnt/' + stiefelsystem_config_json['kernel'].encode('utf-8')
+        )
+        yield os.path.normpath(
+            b'/mnt/' + stiefelsystem_config_json['initrd'].encode('utf-8')
+        )
+        return
+
+    # try to determine kernel from syslinux config
+    syslinux_config = read_binary("/mnt/syslinux/syslinux.cfg")
+    if syslinux_config is not None:
+        yield os.path.normpath(os.path.join(
+            b'/mnt/syslinux',
+            re.search(rb'^\s*LINUX\s+(\S+)\s', syslinux_config, re.M).group(1)
+        ))
+        yield os.path.normpath(os.path.join(
+            b'/mnt/syslinux',
+            re.search(rb'^\s*INITRD\s+(\S+)\s', syslinux_config, re.M).group(1)
+        ))
+        return
+
+    # try to determine kernel from grub config
+    grub_config = read_binary("/mnt/grub/grub.cfg")
+    if grub_config is not None:
+        yield os.path.normpath(
+            b'/mnt/' +
+            re.search(rb'^\s*linux\s+(\S+)\s', grub_config, re.M).group(1)
+        )
+        yield os.path.normpath(
+            b'/mnt/' +
+            re.search(rb'^\s*initrd\s+(\S+)\s', grub_config, re.M).group(1)
+        )
+        return
+
+
 def get_boot_tar(challenge):
-    print("packing kernel and initrd")
-    # read the kernel and initrd
-    subprocess.check_call(['mount', '-oro', BOOTPART, '/mnt'])
-    with open(f'/mnt/{KERNEL}', 'rb') as fileobj:
-        kernelblob = fileobj.read()
-    with open(f'/mnt/{INITRD}', 'rb') as fileobj:
-        initrdblob = fileobj.read()
-    subprocess.check_call(['umount', '/mnt'])
+    print("reading kernel and initrd")
+    try:
+        subprocess.check_call(['mount', '-oro', BOOTPART, '/mnt'])
+        kernel, initrd = find_kernel_and_initrd()
+        print(f"kernel: {kernel.decode(errors='replace')!r}")
+        kernelblob = read_binary(kernel)
+        print(f"initrd: {initrd.decode(errors='replace')!r}")
+        initrdblob = read_binary(initrd)
+    finally:
+        subprocess.check_call(['umount', '/mnt'])
+
     # create the response TAR in-memory
     with io.BytesIO() as fileobj:
         with tarfile.open(fileobj=fileobj, mode='w') as tar:

--- a/overlays/server-os-generic/usr/local/bin/stiefel-autokexec
+++ b/overlays/server-os-generic/usr/local/bin/stiefel-autokexec
@@ -29,8 +29,6 @@ def do_kexec():
         f'systemd.unit=stiefel-server.service',
         f'stiefel_bootdisk={config["bootdisk"]}',
         f'stiefel_bootpart={config["bootpart"]}',
-        f'stiefel_kernel={config["kernel"]}',
-        f'stiefel_initrd={config["initrd"]}',
     ]
 
     command(

--- a/setup-server-os
+++ b/setup-server-os
@@ -21,31 +21,6 @@ ensure_root()
 cli = argparse.ArgumentParser()
 args = cli.parse_args()
 
-
-def get_kernel_path():
-    """
-    returns the path on the boot part of the kernel that should be stiefeled
-    """
-    if 'system-arch' in cfg.modules:
-        return 'vmlinuz-linux'
-    if 'system-debian' in cfg.modules:
-        return 'vmlinuz-' + os.uname()[2]
-    else:
-        raise RuntimeError("no system- module was given")
-
-
-def get_initrd_path():
-    """
-    returns the path on the boot part of the initrd that should be stiefeled
-    """
-    if 'system-arch' in cfg.modules:
-        return 'initramfs-stiefel.img'
-    if 'system-debian' in cfg.modules:
-        return 'initrd.img-' + os.uname()[2]
-    else:
-        raise RuntimeError("could not find the kernel")
-
-
 # ensure that all required tools are installed
 if shutil.which('ifrename') is None:
     raise RuntimeError("could not find ifrename")
@@ -72,8 +47,6 @@ if 'base' in cfg.modules:
         },
         "bootdisk": cfg.boot.disk,
         "bootpart": cfg.boot.part,
-        "kernel": get_kernel_path(),
-        "initrd": get_initrd_path(),
         "stiefelsystem-kernel": cfg.server_setup.stiefelsystem_kernel,
         "stiefelsystem-initrd": cfg.server_setup.stiefelsystem_initrd,
     }
@@ -109,6 +82,14 @@ if 'system-arch' in cfg.modules:
     edit.edit_bash_list('PRESETS', {'stiefel': 'at-end'})
     edit.add_or_edit_var('stiefel_image', '/boot/initramfs-stiefel.img', add_prefix='\n')
     edit.add_or_edit_var('stiefel_options', '-c /etc/mkinitcpio-stiefel.conf -S autodetect')
+    edit.write()
+
+    boot_config = {
+        "kernel": "vmlinuz-linux",
+        "initrd": "initramfs-stiefel.img",
+    }
+    edit = FileEditor('/boot/stiefelsystem.json')
+    edit.set_data(json.dumps(boot_config, indent=4).encode() + b'\n')
     edit.write()
 
     if 'nbd' in cfg.modules:

--- a/test-qemu
+++ b/test-qemu
@@ -18,6 +18,7 @@ and proceed up to `kexec`.
 import argparse
 import base64
 import contextlib
+import json
 import os
 import tempfile
 
@@ -82,6 +83,8 @@ with contextlib.ExitStack() as exit_stack:
         try:
             command('cp', args.kernel, tmppath('mountpoint') + '/kernel')
             command('cp', args.initrd, tmppath('mountpoint') + '/initrd')
+            with open(tmppath('mountpoint') + '/stiefelsystem.json', 'w') as fileobj:
+                json.dump({"kernel": "kernel", "initrd": "initrd"}, fileobj)
         finally:
             command('umount', tmppath('mountpoint'))
 
@@ -99,7 +102,6 @@ with contextlib.ExitStack() as exit_stack:
             "systemd.unit=stiefel-server.service",
             "stiefel_bootdisk=/dev/vda",
             "stiefel_bootpart=/dev/vda1",
-            "stiefel_kernel=kernel stiefel_initrd=initrd",
         ])
 
     else:


### PR DESCRIPTION
The stiefel-server script, when generating boot.tar, after mounting the boot
partition, now reads the GRUB or Syslinux configuration to determine which
kernel and initrd blobs to pack into boot.tar.
Alternatively, a stiefelsystem.json can be created on the boot partition.

This eliminates the need for the kernel and initrd cmdline parameters
for the stiefelsystem server (as started through stiefel-autokexec).