### PR TITLE
Fix debootstrap command

### DIFF
--- a/create-initrd
+++ b/create-initrd
@@ -72,6 +72,7 @@ if not args.skip_setup:
         '--cache-dir=' + os.path.abspath(cfg.path.cache),
         '--variant=minbase',
         '--components=main,contrib,non-free',
+        '--merged-usr',
         '--verbose',
         'stable',
         cfg.path.initrd,


### PR DESCRIPTION
merged-usr fixes bash being only installed on /bin/bash while /etc/passwd sets /usr/bin/bash for root