### PR TITLE
feat: restart autokexec service on config change

### DIFF
--- a/setup-server-os
+++ b/setup-server-os
@@ -13,6 +13,7 @@ from util import (
     command,
     ensure_root,
     ensure_unit_enabled,
+    restart_unit,
     FileEditor,
     install_folder,
 )
@@ -57,7 +58,10 @@ if 'base' in cfg.modules:
     # TODO: rename to autokexec config
     edit = FileEditor('/etc/stiefelsystem/config.json')
     edit.set_data(json.dumps(stiefel_config, indent=4).encode() + b'\n')
-    edit.write()
+    kexecd_config_changed = edit.write()
+
+    if kexecd_config_changed:
+        restart_unit('stiefel-autokexec.service')
 
     # copy the special stiefelsystem initrd to its final location
     # it will be used for autokexec on the server

--- a/util.py
+++ b/util.py
@@ -269,7 +269,7 @@ class FileEditor:
         if not os.path.exists(parentdir):
             warn(f'creating directory {parentdir}')
             if not get_consent():
-                return
+                return False
             os.makedirs(parentdir)
 
         if os.path.exists(self.write_to):
@@ -283,7 +283,7 @@ class FileEditor:
                 # nothing to do
                 print(f'{self.write_to!r}: unchanged')
                 self.ensure_x_flag(need_consent=True)
-                return
+                return False
 
             backup_to = self.write_to + '-stiefelbup'
             warn(f'{self.write_to!r}: overwriting; backing up old version to {backup_to!r}')
@@ -295,7 +295,7 @@ class FileEditor:
             backup_to = None
 
         if not get_consent():
-            return
+            return False
 
         if backup_to is not None:
             os.rename(self.write_to, backup_to)
@@ -304,6 +304,8 @@ class FileEditor:
             fileobj.write(self.data)
 
         self.ensure_x_flag(need_consent=False)
+
+        return True
 
     def ensure_x_flag(self, need_consent):
         if self.executable != os.access(self.write_to, os.X_OK):
@@ -440,6 +442,14 @@ def ensure_unit_enabled(name):
     """
     if command('systemctl', 'is-enabled', name, get_retval=True) != 0:
         command('systemctl', 'enable', name, confirm=True)
+
+
+def restart_unit(name):
+    """
+    Restarts the given systemd unit.
+    Also works for units that are not yet running.
+    """
+    command('systemctl', 'restart', name, confirm=True)
 
 
 def download(url, timeout=20):


### PR DESCRIPTION
This prevents issues where the autokexec service still had the old cmdline loaded and on next kexec, there was a mismatch between cmdline and initrd.